### PR TITLE
Update sklearn-genetic-opt to 0.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sklearn-genetic-opt" %}
-{% set version = "0.12.0" %}
+{% set version = "0.13.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,41 +7,43 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 4e526cc62b424706d6158048a0b50ecb0162fe8015d0c8889aaec1a2d40c0ac6
+  sha256: 2a6200c4f3e808cc6869bf5c4e6c1f6b69c6fc88340c359590e08fffad70eaee
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python >=3.8
+    - python >=3.12
     - pip
+    - setuptools >=77
+    - wheel
   run:
-    - deap >=1.3.3
-    - mlflow >=1.17.0
-    - numpy >=1.19.0
-    - python >=3.8
-    - scikit-learn >=1.1.0
-    - seaborn >=0.11.2
-    - tensorflow >=2.0.0
-    - tqdm >=4.61.1
+    - python >=3.12
+    - scikit-learn >=1.5.0
+    - numpy >=1.26.0
+    - deap >=1.4.0
+    - tqdm >=4.60.0
 
 test:
   imports:
     - sklearn_genetic
+    - sklearn_genetic.callbacks
+    - sklearn_genetic.schedules
   commands:
-    - pip list
     - pip check
   requires:
     - pip
 
 about:
   home: https://github.com/rodrigo-arenas/Sklearn-genetic-opt
-  summary: Scikit-lean models hyperparameters tuning, using evolutionary algorithms
+  summary: Scikit-learn models hyperparameter tuning and feature selection using evolutionary algorithms
   license: MIT
   license_file: LICENSE
+  doc_url: https://rodrigo-arenas.github.io/Sklearn-genetic-opt/
+  dev_url: https://github.com/rodrigo-arenas/Sklearn-genetic-opt
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "sklearn-genetic-opt" %}
 {% set version = "0.13.0" %}
+{% set python_min = "3.12" %}
 
 package:
   name: {{ name|lower }}
@@ -16,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.12
+    - python {{ python_min }}
     - pip
     - setuptools >=77
     - wheel
   run:
-    - python >=3.12
+    - python >={{ python_min }}
     - scikit-learn >=1.5.0
     - numpy >=1.26.0
     - deap >=1.4.0
@@ -35,6 +36,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - numpy >=1.26.0
     - deap >=1.4.0
     - tqdm >=4.60.0
+    - pandas
 
 test:
   imports:


### PR DESCRIPTION
## Changes

- Bump version `0.12.0` → `0.13.0`
- Update `sha256` for new sdist
- **Remove `tensorflow`, `mlflow`, `seaborn` from `run` requirements** — these are optional extras in `pyproject.toml` and were never core dependencies; pinning them as hard requirements made the package unsolvable on most platforms (the `tensorflow` conflict is why `conda install sklearn-genetic-opt` currently fails)
- Update `python` requirement to `>=3.12` (package dropped support for older versions)
- Add `setuptools >=77` and `wheel` to `host` requirements (needed for `--no-build-isolation`)
- Use `--no-deps --no-build-isolation` in build script
- Expand test imports (`callbacks`, `schedules`)
- Fix summary typo; add `doc_url` and `dev_url`

## Notes

Users who need the optional integrations can install them alongside:
```
conda install sklearn-genetic-opt
pip install sklearn-genetic-opt[mlflow]     # or [tensorflow], [plot]
```